### PR TITLE
Set error config properly.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,13 +34,13 @@ export class ApolloError extends ExtendableError {
   _showPath: boolean = false;
 
   constructor(name: string, config: ErrorConfig) {
-    super((arguments[2] && arguments[2].message) || '');
+    super((arguments[1] && arguments[1].message) || '');
 
-    const t = (arguments[2] && arguments[2].time_thrown) || (new Date()).toISOString();
-    const m = (arguments[2] && arguments[2].message) || '';
-    const configData = (arguments[2] && arguments[2].data) || {};
+    const t = (arguments[1] && arguments[1].time_thrown) || (new Date()).toISOString();
+    const m = (arguments[1] && arguments[1].message) || '';
+    const configData = (arguments[1] && arguments[1].data) || {};
     const d = { ...this.data, ...configData };
-    const opts = ((arguments[2] && arguments[2].options) || {});
+    const opts = ((arguments[1] && arguments[1].options) || {});
 
 
     this.name = name;


### PR DESCRIPTION
The constructor ApolloError is failing to get the config argument. It is trying to get it from the 3rd position of the arguments object: (arguments[2]). It should be accessing it from the 2nd position: (arguments[1]).