### PR TITLE
Make serialized error spec compliant

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,13 @@ export interface ErrorConfig {
 
 export interface ErrorInfo {
   message: string;
-  name: string;
-  time_thrown: string;
-  data?: object;
   path?: string;
   locations?: any;
+  extensions?: {
+    name: string;
+    time_thrown: string;
+    data?: object;
+  };
 }
 
 export class ApolloError extends ExtendableError {
@@ -56,11 +58,13 @@ export class ApolloError extends ExtendableError {
 
     let error: ErrorInfo = {
       message,
-      name,
-      time_thrown,
-      data,
       path,
-      locations
+      locations,
+      extensions: {
+        name,
+        time_thrown,
+        data
+      }
     };
 
     if (_showLocations) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -31,7 +31,7 @@ describe('createError', () => {
         },
       });
 
-      const { message, name, time_thrown, data } = e.serialize();
+      const { message, extensions: { name, time_thrown, data } } = e.serialize();
       expect(message).to.equal('A foo 2.0 error has occurred');
       expect(name).to.equal('FooError');
       expect(time_thrown).to.equal(e.time_thrown);


### PR DESCRIPTION
An update recently in [`facebook/graphql/spec/Section 7 -- Response.md`](https://github.com/facebook/graphql/blob/master/spec/Section%207%20--%20Response.md) specify that GraphQL services may provide an additional entry to errors with key `extensions`. Although non-specified entries are not violations, they are still discouraged.

This update try to follow through with the spec recommendation.