### PR TITLE
Rename ctorData to ctorConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,14 +36,17 @@ export class ApolloError extends ExtendableError {
   // NOTE: The object passed to the Constructor is actually `ctorData`.
   //       We are binding the constructor to the name and config object
   //       for the first two parameters inside of `createError`
-  constructor(name: string, config: ErrorConfig, ctorData: any) {
-    super((ctorData && ctorData.message) || '');
+  constructor(name: string, config: ErrorConfig, ctorConfig: ErrorConfig) {
+    super((ctorConfig && ctorConfig.message) || (config && config.message) || '');
 
-    const t = (ctorData && ctorData.time_thrown) || (new Date()).toISOString();
-    const m = (ctorData && ctorData.message) || '';
-    const configData = (ctorData && ctorData.data) || {};
-    const d = { ...this.data, ...configData };
-    const opts = ((ctorData && ctorData.options) || {});
+    const t = (ctorConfig && ctorConfig.time_thrown) || (config && config.time_thrown) || (new Date()).toISOString();
+    const m = (ctorConfig && ctorConfig.message) || (config && config.message) || '';
+    const ctorData = (ctorConfig && ctorConfig.data) || {};
+    const configData = (config && config.data) || {};
+    const d = { ...this.data, ...configData, ...ctorData };
+    const ctorOptions = (ctorConfig && ctorConfig.options) || {};
+    const configOptions = (config && config.options) || {};
+    const opts = { ...configOptions, ...ctorOptions };
 
 
     this.name = name;


### PR DESCRIPTION
Previously, ctorData is accessing all the attributes listed in ErrorConfig so it should be define as ErrorConfig instance and renamed as ctorConfig.

The common use case will bind the first 2 arguments of ApolloError.constructor() to name and a common configuration object, leaving the ctorConfig to provide the final customization.

This fix is similar to #34 and #29 

We make sure that ctorConfig take precedence over config and merge them whenever necessary.

It may seems scary that I made a lot of changes, but a more powerful diff tool does show that the change is minimum.

![screenshot 2018-03-28 10 57 40](https://user-images.githubusercontent.com/297156/38006518-f24b8814-3277-11e8-8489-2cf9199f0eb2.png)
