### PR TITLE
Add internalData property

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ const resolverThatThrowsError = (root, params, context) => {
   throw new FooError({
     data: {
       something: 'important'
+    },
+    internalData: {
+      error: `The SQL server died.`
     }
   });
 }
@@ -83,18 +86,39 @@ Witness glorious simplicity:
 }
 ```
 
+The `internalData` property is meant for data you want to store on the error object (e.g. for logging), but not send out to your end users.
+You can utilize this data for logging purposes.
+
+```js
+import { isInstance as isApolloErrorInstance, formatError as formatApolloError } from 'apollo-errors';
+
+function formatError(error) {
+  const { originialError } = error;
+  if (isApolloErrorInstance(originalError)) {
+    // log internalData to stdout but not include it in the formattedError
+    console.log(JSON.stringify({
+      type: `error`,
+      data: originalError.data,
+      internalData: originalError.internalData
+    }));
+  }
+  return formatApolloError(error)
+}
+
+``` 
+
 ## API
 
-### ApolloError ({ [time_thrown: String, data: Object, message: String ]})
+### ApolloError ({ [time_thrown: String, data: Object, internalData: object message: String ]})
 
 Creates a new ApolloError object.  Note that `ApolloError` in this context refers
 to an error class created and returned by `createError` documented below.  Error can be
-initialized with a custom `time_thrown` ISODate (default is current ISODate), `data` object (which will be merged with data specified through `createError`, if it exists), and `message` (which will override the message specified through `createError`).
+initialized with a custom `time_thrown` ISODate (default is current ISODate), `data` object (which will be merged with data specified through `createError`, if it exists), `internalData` object (which will be merged with internalData specified trough `createError`) and `message` (which will override the message specified through `createError`).
 
 
-### createError(name, {message: String, [data: Object, options: Object]}): ApolloError
+### createError(name, {message: String, [data: Object, internalData: object, options: Object]}): ApolloError
 
-Creates and returns an error class with the given `name` and `message`, optionally initialized with the given `data` and `options`.  `data` passed to `createError` will later be merged with any data passed to the constructor.
+Creates and returns an error class with the given `name` and `message`, optionally initialized with the given `data`, `internalData` and `options`.  `data` and `internalData` passed to `createError` will later be merged with any data passed to the constructor.
 
 #### Options (default):
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export class ApolloError extends ExtendableError {
   message: string;
   time_thrown: string;
   data: object;
+  internalData: object;
   path: any;
   locations: any;
   _showLocations: boolean = false;
@@ -43,8 +44,11 @@ export class ApolloError extends ExtendableError {
     const t = (ctorConfig && ctorConfig.time_thrown) || (config && config.time_thrown) || (new Date()).toISOString();
     const m = (ctorConfig && ctorConfig.message) || (config && config.message) || '';
     const ctorData = (ctorConfig && ctorConfig.data) || {};
+    const ctorInternalData = (ctorConfig && ctorConfig.internalData) || {}
     const configData = (config && config.data) || {};
+    const configInternalData = (config && config.internalData) || {}
     const d = { ...this.data, ...configData, ...ctorData };
+    const id = { ...this.internalData, ...configInternalData, ...ctorInternalData}
     const ctorOptions = (ctorConfig && ctorConfig.options) || {};
     const configOptions = (config && config.options) || {};
     const opts = { ...configOptions, ...ctorOptions };
@@ -54,6 +58,7 @@ export class ApolloError extends ExtendableError {
     this.message = m;
     this.time_thrown = t;
     this.data = d;
+    this.internalData = id;
     this._showLocations = !!opts.showLocations;
     this._showPath = !!opts.showPath;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export interface ErrorConfig {
   message: string;
   time_thrown?: string;
   data?: object;
+  internalData?: object;
   options?: {
     showPath?: boolean;
     showLocations?: boolean;

--- a/test/spec.js
+++ b/test/spec.js
@@ -147,6 +147,9 @@ describe('formatError', () => {
       });
 
       const e = new FooError();
+      expect(e.internalData).to.to.eql({
+        secret: 'SQL ERROR'
+      })
       const s = formatError(e);
       expect(s.internalData).to.eq(undefined)
     })

--- a/test/spec.js
+++ b/test/spec.js
@@ -137,4 +137,18 @@ describe('formatError', () => {
       });
     });
   });
+  context('error has internalData', () => {
+    it('does not include the internalData property', () => {
+      const FooError = createError('FooError', {
+        message: 'A foo error has occurred',
+        internalData: {
+          secret: 'SQL ERROR'
+        }
+      });
+
+      const e = new FooError();
+      const s = formatError(e);
+      expect(s.internalData).to.eq(undefined)
+    })
+  })
 });


### PR DESCRIPTION
This PR adds an `internalData` property to the `ErrorConfig` interface.

It also adds a (silly) test that ensures, the internalData is not present after using `formatError`.

Implements #30