### PR TITLE
Fixed broken test for spec compliance PRs

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -53,7 +53,7 @@ describe('createError', () => {
       });
       const e = new FooError({data: {foo: 'bar'}});
 
-      const { message, name, time_thrown, data } = e.serialize();
+      const { message, extensions: { name, time_thrown, data } } = e.serialize();
       expect(message).to.equal('A foo error has occurred');
       expect(name).to.equal('FooError');
       expect(time_thrown).to.equal(e.time_thrown);


### PR DESCRIPTION
PR for #51

> name, time_throw and data are now under extensions so we need to extract the values from there instead

This change is just so the CI tests pass…